### PR TITLE
cleanup docker fixuid

### DIFF
--- a/docker/.bashrc
+++ b/docker/.bashrc
@@ -4,3 +4,6 @@
 # container is brought up, this command is automatically executed when the
 # .bashrc is sourced.
 source /home/docker/ament_ws/install/setup.bash
+
+alias clw="rm -rf build/ && rm -rf install/"
+alias dbd="colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo && source install/setup.bash"

--- a/docker/fixuid_setup.sh
+++ b/docker/fixuid_setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# ================= User Setup ===================
+apt-get update && apt-get install -y curl sudo && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add a docker user so that created files in the docker container are owned by a non-root user
+addgroup --gid 1000 docker && \
+    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
+    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+
+# Remap the docker user and group to be the same uid and group as the host user.
+# Any created files by the docker container will be owned by the host user.
+USER=docker && \
+    GROUP=docker && \                                                                     
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
+    chown root:root /usr/local/bin/fixuid && \                                                                              
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \                                                                                               
+    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/ \n  - /tmp/" > /etc/fixuid/config.yml

--- a/docker/gazebo/gazeboserver.Dockerfile
+++ b/docker/gazebo/gazeboserver.Dockerfile
@@ -1,3 +1,4 @@
+# ================= Dependencies ===================
 FROM ros:humble AS base
 
 RUN apt-get update && apt-get install -y curl && \
@@ -14,28 +15,16 @@ RUN apt-get -y install ros-${ROS_DISTRO}-ros-gz ignition-fortress
 RUN apt-get -y install ros-humble-velodyne-gazebo-plugins
 RUN echo $GAZEBO_PLUGIN_PATH=/opt/ros/humble/lib
 
-
-# Add a docker user so that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN sudo chsh -s /bin/bash
 ENV SHELL=/bin/bash
 
+# ================= Repositories ===================
 FROM base as repo
 
 USER docker:docker

--- a/docker/infrastructure/vis_tools/foxglove.Dockerfile
+++ b/docker/infrastructure/vis_tools/foxglove.Dockerfile
@@ -15,21 +15,9 @@ RUN apt-get update && \
     ros-$ROS_DISTRO-rosbridge-server \
     ros-$ROS_DISTRO-topic-tools
 
-# Add a docker user so that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/robot/control.Dockerfile
+++ b/docker/robot/control.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/robot/nav.Dockerfile
+++ b/docker/robot/nav.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/robot/occupancy.Dockerfile
+++ b/docker/robot/occupancy.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/cpp/aggregator.Dockerfile
+++ b/docker/samples/cpp/aggregator.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/cpp/producer.Dockerfile
+++ b/docker/samples/cpp/producer.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/cpp/transformer.Dockerfile
+++ b/docker/samples/cpp/transformer.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/python/aggregator.Dockerfile
+++ b/docker/samples/python/aggregator.Dockerfile
@@ -1,24 +1,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/python/producer.Dockerfile
+++ b/docker/samples/python/producer.Dockerfile
@@ -1,23 +1,10 @@
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/samples/python/transformer.Dockerfile
+++ b/docker/samples/python/transformer.Dockerfile
@@ -2,24 +2,11 @@
 # ================= Dependencies ===================
 FROM ros:humble AS base
 
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+# ADD DEPENDENCIES HERE
 
-# Add a docker user so we that created files in the docker container are owned by a non-root user
-RUN addgroup --gid 1000 docker && \
-    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/bash --disabled-password --gecos "" docker && \
-    echo "docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-# Remap the docker user and group to be the same uid and group as the host user.
-# Any created files by the docker container will be owned by the host user.
-RUN USER=docker && \
-    GROUP=docker && \                                                                     
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \                                                                                                            
-    chown root:root /usr/local/bin/fixuid && \                                                                              
-    chmod 4755 /usr/local/bin/fixuid && \
-    mkdir -p /etc/fixuid && \                                                                                               
-    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/docker/" > /etc/fixuid/config.yml
-
+# fix user permissions for mounted volumes
+COPY docker/fixuid_setup.sh /project/fixuid_setup.sh
+RUN /project/fixuid_setup.sh
 USER docker:docker
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/watod-config.sh
+++ b/watod-config.sh
@@ -7,7 +7,7 @@
 ##   - gazebo           :   starts robot simulator (gazebo)
 ##   - samples          :   starts up sample nodes for reference
 
-# ACTIVE_PROFILES=""
+ACTIVE_PROFILES="vis_tools gazebo samples robot"
 
 ## Name to append to docker containers. DEFAULT = <your_watcloud_username>
 


### PR DESCRIPTION
This pr removes the large fixuid docker commands from the dockerfile itself. It should be less intimidating to look at the dockerfile, and fixuid can be fully treated as a black box. 

The only time we need to touch the fixuid script is when file permissions are amuck. Any mounted volume in /tmp/ or /home/docker should have their permissions fixed.