### PR TITLE
Fix grep command in dockerfiles

### DIFF
--- a/docker/gazebo/gazeboserver.Dockerfile
+++ b/docker/gazebo/gazeboserver.Dockerfile
@@ -11,7 +11,7 @@ COPY src/gazebo gazebo
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/robot/robot.Dockerfile
+++ b/docker/robot/robot.Dockerfile
@@ -16,7 +16,7 @@ COPY src/robot/bringup_robot bringup_robot
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/cpp_aggregator.Dockerfile
+++ b/docker/samples/cpp_aggregator.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/cpp_producer.Dockerfile
+++ b/docker/samples/cpp_producer.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/cpp_transformer.Dockerfile
+++ b/docker/samples/cpp_transformer.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_aggregator.Dockerfile
+++ b/docker/samples/py_aggregator.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_producer.Dockerfile
+++ b/docker/samples/py_producer.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_transformer.Dockerfile
+++ b/docker/samples/py_transformer.Dockerfile
@@ -12,7 +12,7 @@ COPY src/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/vis_tools/foxglove.Dockerfile
+++ b/docker/vis_tools/foxglove.Dockerfile
@@ -11,7 +11,7 @@ COPY src/wato_msgs wato_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | (grep 'apt-get install' || true) \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 


### PR DESCRIPTION
This particular command (used in all the dockerfiles)
```
grep 'apt-get install'
```
is not robust. When there are no matches `grep` gives return code 1, **not** 0 which causes the image to stop building. This particular case arises when rosdep finds no dependencies to install. I am not sure why we are encountering this case all of a sudden after rebuilding the base images.  The proposed change is a kind of "hacky" fix to make sure grep always returns exit code 0:
```
(grep 'apt-get install' || true)
```