### PR TITLE
onboarding completed from my end, made some changes to the dockerfiles

### DIFF
--- a/docker/robot/robot.Dockerfile
+++ b/docker/robot/robot.Dockerfile
@@ -5,6 +5,14 @@ FROM ${BASE_IMAGE} AS source
 
 WORKDIR ${AMENT_WS}/src
 
+# Harden APT in this stage
+RUN set -eux; \
+  printf 'Acquire::Retries "6";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::ForceIPv4 "true";\n' \
+    >/etc/apt/apt.conf.d/99-robust-apt; \
+  sed -i 's|http://archive.ubuntu.com/ubuntu|mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list; \
+  sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list; \
+  apt-get update
+
 # Copy in source code 
 COPY src/robot/odometry_spoof odometry_spoof
 COPY src/robot/costmap costmap
@@ -22,6 +30,14 @@ RUN apt-get -qq update && rosdep update && \
 
 ################################# Dependencies ################################
 FROM ${BASE_IMAGE} AS dependencies
+
+# Harden APT in this stage
+RUN set -eux; \
+  printf 'Acquire::Retries "6";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::ForceIPv4 "true";\n' \
+    >/etc/apt/apt.conf.d/99-robust-apt; \
+  sed -i 's|http://archive.ubuntu.com/ubuntu|mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list; \
+  sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list; \
+  apt-get update
 
 # ADD MORE DEPENDENCIES HERE
 

--- a/src/robot/costmap/CMakeLists.txt
+++ b/src/robot/costmap/CMakeLists.txt
@@ -1,19 +1,20 @@
 cmake_minimum_required(VERSION 3.10)
 project(costmap)
-
+ 
 # Set compiler to use C++ 17 standard
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
-
+ 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
-
+ 
 # Search for dependencies required for building this package
 find_package(ament_cmake REQUIRED) # ROS2 build tool
 find_package(rclcpp REQUIRED)      # ROS2 C++ package
-
+find_package(std_msgs REQUIRED)    # YOU ARE ONLY ADDING THIS TO THE FILE
+ 
 # Compiles source files into a library
 # A library is not executed, instead other executables can link
 # against it to access defined methods and classes.
@@ -25,21 +26,24 @@ add_library(costmap_lib
 target_include_directories(costmap_lib
   PUBLIC include)
 # Add ROS2 dependencies required by package
-ament_target_dependencies(costmap_lib rclcpp)
-
+ament_target_dependencies(costmap_lib 
+  rclcpp
+  std_msgs # YOU ARE ONLY ADDING THIS TO THE FILE
+)
+ 
 # Create ROS2 node executable from source files
 add_executable(costmap_node src/costmap_node.cpp)
 # Link to the previously built library to access costmap classes and methods
 target_link_libraries(costmap_node costmap_lib)
-
+ 
 # Copy executable to installation location
 install(TARGETS
   costmap_node
   DESTINATION lib/${PROJECT_NAME})
-
+ 
 # Copy launch and config files to installation location
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME})
-
+ 
 ament_package()

--- a/src/robot/costmap/include/costmap_node.hpp
+++ b/src/robot/costmap/include/costmap_node.hpp
@@ -1,16 +1,23 @@
 #ifndef COSTMAP_NODE_HPP_
 #define COSTMAP_NODE_HPP_
-
+ 
 #include "rclcpp/rclcpp.hpp"
-
+#include "std_msgs/msg/string.hpp"
+ 
 #include "costmap_core.hpp"
-
+ 
 class CostmapNode : public rclcpp::Node {
   public:
     CostmapNode();
-
+    
+    // Place callback function here
+    void publishMessage();
+ 
   private:
     robot::CostmapCore costmap_;
+    // Place these constructs here
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr string_pub_;
+    rclcpp::TimerBase::SharedPtr timer_;
 };
-
+ 
 #endif 

--- a/src/robot/costmap/package.xml
+++ b/src/robot/costmap/package.xml
@@ -3,18 +3,21 @@
   <name>costmap</name>
   <version>0.0.0</version>
   <description>A sample ROS package for pubsub communication</description>
-
+ 
   <maintainer email="oleather@watonomous.ca">Owen Leather</maintainer>
   <license>Apache2.0</license>
-
+ 
   <!--https://www.ros.org/reps/rep-0149.html#dependency-tags-->
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
-
+ 
+  <!--YOU ARE ADDING THIS MAINLY-->
+  <depend>std_msgs</depend>
+ 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-
+ 
   <!--https://www.ros.org/reps/rep-0149.html#export-->
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/robot/costmap/src/costmap_node.cpp
+++ b/src/robot/costmap/src/costmap_node.cpp
@@ -1,10 +1,22 @@
 #include <chrono>
 #include <memory>
-
+ 
 #include "costmap_node.hpp"
-
-CostmapNode::CostmapNode() : Node("costmap"), costmap_(robot::CostmapCore(this->get_logger())) {}
-
+ 
+CostmapNode::CostmapNode() : Node("costmap"), costmap_(robot::CostmapCore(this->get_logger())) {
+  // Initialize the constructs and their parameters
+  string_pub_ = this->create_publisher<std_msgs::msg::String>("/test_topic", 10);
+  timer_ = this->create_wall_timer(std::chrono::milliseconds(500), std::bind(&CostmapNode::publishMessage, this));
+}
+ 
+// Define the timer to publish a message every 500ms
+void CostmapNode::publishMessage() {
+  auto message = std_msgs::msg::String();
+  message.data = "Hello, ROS 2!";
+  RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
+  string_pub_->publish(message);
+}
+ 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);

--- a/watod-config.sh
+++ b/watod-config.sh
@@ -15,7 +15,7 @@
 ##   - robot            :   starts up robot nodes
 ##   - samples          :   starts up sample nodes for reference
 
-# ACTIVE_MODULES=""
+ACTIVE_MODULES="robot gazebo vis_tools"
 
 ################################# MODE OF OPERATION #################################
 ## Possible modes of operation when running watod.


### PR DESCRIPTION
updated the Dockerfiles for the Gazebo server, Robot, and Foxglove (vis_tools) modules to harden package installs and fix build failures caused by Ubuntu mirrors. In each file’s dependencies stage, I added an APT setup with retries, timeouts, forced IPv4, and switched archive.ubuntu.com to the Ubuntu mirror list, followed by apt-get update
